### PR TITLE
Add `BluetoothWeb` library

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ unacceptable behavior to hello@swiftwasm.org.
 * [JavaScriptKit](https://github.com/kateinoigakukun/JavaScriptKit/) - Swift framework to interact with JavaScript through WebAssembly.
 * [SwiftWebUI](https://github.com/carson-katri/SwiftWebUI) - SwiftUI with support for WebAssembly.
 * [Tokamak](https://github.com/swiftwasm/Tokamak) - SwiftUI-compatible framework for building browser apps with WebAssembly.
+* [BluetoothWeb](https://github.com/PureSwift/BluetoothWeb) - Swift framework to interact with [Web Bluetooth API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Bluetooth_API) through WebAssembly.
 
 ## Developer tools
 


### PR DESCRIPTION
Swift library for [Web Bluetooth API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Bluetooth_API)
Demo at https://pureswift.github.io/BluetoothWeb, only Chrome and Opera are supported for now.

![2021-12-26 4 49 42 PM](https://user-images.githubusercontent.com/3419766/147489667-5786a6c0-6e9c-4cd2-84f2-1e396f752345.gif)